### PR TITLE
Adding a regex fix for non-compliant mod IDs and item names

### DIFF
--- a/src/main/java/org/spoorn/starteritems/StarterItems.java
+++ b/src/main/java/org/spoorn/starteritems/StarterItems.java
@@ -35,7 +35,7 @@ public class StarterItems implements ModInitializer {
     
     public static final String MODID = "starteritems";
     public static final String JOINED_ID = MODID + "_joined";
-    private static final Pattern ITEM_REGEX = Pattern.compile("^((?<count>\\d+)\\s+)?\\s*(?<item>\\w+:\\w+)\\s*(\\s+(?<nbt>\\{.*\\}))?$");
+    private static final Pattern ITEM_REGEX = Pattern.compile("^((?<count>\\d+)\\s+)?\\s*(?<item>[^:\\ ]+:[^:\\ ]+)\\s*(\\s+(?<nbt>\\{.*\\}))?$");
     
     // Keep track of players that have been loaded.  This is to avoid sending the welcome message when player reloads
     // as in changing dimensions.


### PR DESCRIPTION
Fixed non-compliant mod IDs and item names
![Screenshot_20230222_114139](https://user-images.githubusercontent.com/16451875/220597574-646795ec-0720-4d50-ad68-0311e515114d.png)
